### PR TITLE
Fix: avoid `ERR_INVALID_CHAR` by sending ASCII Last-Modified header

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+# 5.2.1 
+* Fixes crash in SDK dev-server when locale contains non-ASCII characters.
+  `Last-Modified` header is now sent as RFC-1123 ASCII.
+
+
 # 5.2.0
 * Fixes issue publishing templates with complex settings
 * Improves html sanitation in template publishing workflow

--- a/server/index.js
+++ b/server/index.js
@@ -405,7 +405,7 @@ module.exports = function(template_dir, options) {
 		const filename = path.resolve(template_dir, "data", req.params.id + ".csv");
 		const { mtime: last_updated } = fs.statSync(filename);
 		res.status(200).header("Content-Type", "text/csv")
-			.header("Last-Modified", last_updated) // Send last modified time
+			.header("Last-Modified", new Date(last_updated).toUTCString()) // Send last modified time
 			.sendFile(filename);
 	});
 


### PR DESCRIPTION
### Problem

`flourish run` crashes with `TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Last-Modified"]` on any machine whose locale makes `Date#toString()` include a non-ASCII character (Italian, French, Spanish…).

### Reproduction

```
export LANG=it_IT.UTF-8 LC_ALL=it_IT.UTF-8 TZ=Europe/Rome
flourish run         # throws on Node 18/20/21/22
```

### Fix

Send `new Date(last_updated).toUTCString()`, which is always ASCII (`Tue, 13 May 2025 13:48:02 GMT`).

### Notes

* No behavioural change for existing users in English locales
* Version not yet bumped but release notes boldly added for 5.2.1
* [Original issue](https://canvateam.zendesk.com/agent/tickets/11979218)